### PR TITLE
Fix GitHub casing in mini menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
         <nav class="mini-menu" id="miniMenu">
             <span class="hover-bg mini-hover-bg"></span>
             <ul>
-                <li><a href="#" target="_blank"><i class="ti ti-brand-github"></i> Github</a></li>
+                <li><a href="#" target="_blank"><i class="ti ti-brand-github"></i> GitHub</a></li>
                 <li><a href="#" target="_blank"><i class="ti ti-brand-linkedin"></i> LinkedIn</a></li>
                 <li><a href="#" target="_blank"><i class="ti ti-mail"></i> Mail</a></li>
                 <li><a href="#" target="_blank"><i class="ti ti-file-cv"></i> Resume</a></li>


### PR DESCRIPTION
## Summary
- correct GitHub brand casing in mini-menu link